### PR TITLE
Fixed Failed to activate the dash-on-cursor package error

### DIFF
--- a/lib/dash-on-cursor.coffee
+++ b/lib/dash-on-cursor.coffee
@@ -23,10 +23,10 @@ grammar2docsets =
 
 module.exports =
   activate: (state) ->
-    atom.workspaceView.command "dash-on-cursor:open", => @open()
+    atom.commands.add 'atom-workspace','dash-on-cursor:open': => @open()
 
   open: ->
-    editor = atom.workspace.getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
     return unless editor?
 
     token = editor.tokenForBufferPosition(editor.getCursorBufferPosition())


### PR DESCRIPTION
Fixed Failed to activate the dash-on-cursor package #4 
dash-on-cursor.coffee was using deprecated commands.

Updated per new Atom CommandRegistry API
https://atom.io/docs/api/v0.210.0/CommandRegistry
